### PR TITLE
SC-1843-[Consignment service] - RequestNumber is different between SC…

### DIFF
--- a/id-encoder/pom.xml
+++ b/id-encoder/pom.xml
@@ -6,22 +6,22 @@
 
   <groupId>com.gfg.id-encoder</groupId>
   <artifactId>id-encoder</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0</version>
 
   <name>id-encoder</name>
   <url>https://github.com/GFG/java-packages</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/id-encoder/src/main/java/com/gfg/idencoder/IdEncoder.java
+++ b/id-encoder/src/main/java/com/gfg/idencoder/IdEncoder.java
@@ -9,8 +9,7 @@ public class IdEncoder {
     private static final int MEDIUM = 7;
 
     private static final Character[] DICTIONARY =
-            new Character[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'};
-
+            "0123456789ABCDEFGHIJKLMNOPRSTUVWXYZ".chars().mapToObj(c -> (char)c).toArray(Character[]::new);
     private static final int BASE = DICTIONARY.length;
 
     public static String encodeShort(Long value) {

--- a/id-encoder/src/test/java/com/gfg/idencoder/IdEncoderTest.java
+++ b/id-encoder/src/test/java/com/gfg/idencoder/IdEncoderTest.java
@@ -18,6 +18,7 @@ public class IdEncoderTest {
                 {5419L, "10004EU"},
                 {1317L, "100012M"},
                 {573437L, "100DD3X"},
+                {100000062L, "11WMCOM"},
         });
     }
 


### PR DESCRIPTION
Replace existing Character[] DICTIONARY  with SC PHP code from `use Ramsey\Uuid\Uuid`;`class SellerCenter_Uuid`
to make the IdEncoder consistent with SC
 ```public static function generateEncodedString($number, $length = false, $decode = false)
    {
        if (!is_numeric($number) && $decode === false) {
            throw new \LogicException('Only integer can be encoded');
        }
        $out = '';
        $index = '0123456789ABCDEFGHIJKLMNOPRSTUVWXYZ';
        $base = strlen($index);```
        PS: Although it missing `Q` character we decided to keep it as current to make the old value can't break 